### PR TITLE
4 4 api cards 1 pts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import {createServer} from "http";
 import {env} from "./env";
 import express from "express";
 import cors from "cors";
+import {cardRouter} from "./routes/card.routes";
 
 // Create Express app
 export const app = express();
@@ -23,6 +24,8 @@ app.use(express.static('public'));
 app.get("/api/health", (_req, res) => {
     res.json({status: "ok", message: "TCG Backend Server is running"});
 });
+
+app.use('api/cards', cardRouter);
 
 // Start server only if this file is run directly (not imported for tests)
 if (require.main === module) {

--- a/src/routes/card.routes.ts
+++ b/src/routes/card.routes.ts
@@ -1,0 +1,19 @@
+import {Router, Response} from "express";
+import {prisma} from "../database";
+import {AllCardRequest} from "../types/card.types";
+
+export const cardRouter = Router();
+
+cardRouter.get("/", async (_req: AllCardRequest, res: Response) => {
+    try {
+        const cards = await prisma.card.findMany({
+            orderBy: {
+                pokedexNumber: 'asc'
+            }
+        });
+        
+        res.status(200).json(cards);
+    } catch (error) {
+        res.status(500).json({error: "Internal server error"});
+    }
+});

--- a/src/types/card.types.ts
+++ b/src/types/card.types.ts
@@ -1,0 +1,15 @@
+import {Request} from 'express';
+
+export interface AllCardRequestBody {
+    id: number;
+    name: string;
+    hp: number;
+    attack: number;
+    type: string;
+    pokedexNumber: number;
+    imUrl: string;
+    createdAt: Date;
+    updatedAt: Date;
+}
+
+export type AllCardRequest = Request<{}, any, AllCardRequestBody[]>;


### PR DESCRIPTION
J'ai, dans cette partie, ajouté le endpoint pour récupérer la liste de toutes les cartes triées par ordre croissant. J'ai également appliqué le refactoring au niveau du type de la requête, donc un fichier card.types est également fourni. Enfin, toujours inclure l'api au index.ts. 

Le résultat est montré ci-dessous via bruno : 

<img width="1580" height="851" alt="image" src="https://github.com/user-attachments/assets/0d26f4de-054f-443b-a327-71879e68b76e" />


je ne peux pas lister le résultat entier mais ils sont bien triés dans l'ordre de leur numéro de pokédex