### PR TITLE
5 5 api decks   crud complet 3 pts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import express from "express";
 import cors from "cors";
 import {authRouter} from "./routes/auth.routes";
 import {cardRouter} from "./routes/card.routes";
+import {deckRouter} from "./routes/deck.routes";
 
 
 // Create Express app
@@ -28,7 +29,8 @@ app.get("/api/health", (_req, res) => {
 });
 
 app.use("/api/auth", authRouter);
-app.use('api/cards', cardRouter);
+app.use('/api/cards', cardRouter);
+app.use('/api/decks', deckRouter);
 
 // Start server only if this file is run directly (not imported for tests)
 if (require.main === module) {

--- a/src/middlewares/auth.middleware.ts
+++ b/src/middlewares/auth.middleware.ts
@@ -1,9 +1,9 @@
 import {Response, NextFunction} from "express";
+import {Request} from "express";
 import jwt from "jsonwebtoken";
 import {env} from "../env";
-import { AuthenticatedRequest } from "../types/auth.types";
 
-export const authenticateToken = (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+export const authenticateToken = (req: Request<any, any, any>, res: Response, next: NextFunction) => {
     const authHeader = req.headers.authorization;
     const token = authHeader?.split(" ")[1];
 
@@ -19,6 +19,7 @@ export const authenticateToken = (req: AuthenticatedRequest, res: Response, next
         return res.status(401).json({error: "Invalid or expired token"});
     }
 };
+
 
 
 

--- a/src/middlewares/auth.middleware.ts
+++ b/src/middlewares/auth.middleware.ts
@@ -1,7 +1,7 @@
 import {Response, NextFunction} from "express";
 import jwt from "jsonwebtoken";
 import {env} from "../env";
-import { JWTRequest } from "../types/auth.types";
+import { AuthenticatedRequest } from "../types/auth.types";
 
 export const authenticateToken = (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
     const authHeader = req.headers.authorization;
@@ -19,6 +19,7 @@ export const authenticateToken = (req: AuthenticatedRequest, res: Response, next
         return res.status(401).json({error: "Invalid or expired token"});
     }
 };
+
 
 
 

--- a/src/middlewares/auth.middleware.ts
+++ b/src/middlewares/auth.middleware.ts
@@ -3,7 +3,7 @@ import jwt from "jsonwebtoken";
 import {env} from "../env";
 import { JWTRequest } from "../types/auth.types";
 
-export const authenticateToken = (req: JWTRequest, res: Response, next: NextFunction) => {
+export const authenticateToken = (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
     const authHeader = req.headers.authorization;
     const token = authHeader?.split(" ")[1];
 
@@ -19,5 +19,6 @@ export const authenticateToken = (req: JWTRequest, res: Response, next: NextFunc
         return res.status(401).json({error: "Invalid or expired token"});
     }
 };
+
 
 

--- a/src/routes/deck.routes.ts
+++ b/src/routes/deck.routes.ts
@@ -1,0 +1,140 @@
+import {Router, Response} from "express";
+import type {Request} from "express";
+import {prisma} from "../database";
+import {authenticateToken} from "../middlewares/auth.middleware";
+import {CreateDeckRequest, UpdateDeckRequest} from "../types/deck.types";
+
+export const deckRouter = Router();
+
+deckRouter.post("/", authenticateToken, async (req: CreateDeckRequest, res: Response) => {
+    try {
+        const name = req.body.name;
+        const userId = req.user!.userId;
+        const cards = req.body.cards;
+
+        if (!name) {
+            return res.status(400).json("Missing deck name");
+        }
+
+        if (!cards || !Array.isArray(cards) || cards.length !== 10) {
+            return res.status(400).json("A deck must contain exactly 10 cards");
+        }
+
+        const deck = await prisma.deck.create({
+            data: {
+                name: name,
+                userId: userId,
+                cards : {
+                    create: cards.map((cardId: number) => ({ cardId }))
+                }
+            }
+        });
+
+        return res.status(201).json("deck created successfully :" + deck.name);
+    } catch (error) {
+        return res.status(500).json({error: "Internal server error"});
+    }
+});
+
+deckRouter.get("/mine", authenticateToken, async (req: Request, res: Response) => {
+    try {
+        const userId = req.user!.userId;
+
+        const decks = await prisma.deck.findMany({
+            where: {userId: userId}
+        })
+        return res.status(200).json(decks.map(deck => ({
+            id: deck.id,
+            name: deck.name
+        })));
+    } catch (error) {
+        return res.status(500).json({error: "Internal server error"});
+    }
+});
+
+deckRouter.get("/:id", authenticateToken, async (req: Request, res: Response) => {
+    try {
+        const userId = req.user!.userId;
+        const deckId = parseInt(req.params.id!);
+
+        if (isNaN(deckId)) {
+            return res.status(400).json("Invalid deck ID");
+        }
+
+        const deck = await prisma.deck.findFirst({
+            where: {id: deckId, userId}
+        })
+        
+        if (!deck) {
+            return res.status(404).json({error: "Deck not found"});
+        }
+        
+        return res.status(200).json(deck);
+    } catch (error) {
+        return res.status(500).json({error: "Internal server error"});
+    }
+}
+);
+
+deckRouter.patch("/:id", authenticateToken, async (req: UpdateDeckRequest, res: Response) => {
+    try {
+        const userId = req.user!.userId;
+        const deckId = parseInt(req.params.id!);
+        const {name, cards} = req.body;
+
+        if (isNaN(deckId)) {
+            return res.status(400).json("Invalid deck ID");
+        }
+
+        if (!name) {
+            return res.status(400).json("Missing deck name");
+        }
+
+        if (!cards || !Array.isArray(cards) || cards.length !== 10) {
+            return res.status(400).json("A deck must contain exactly 10 cards");
+        }
+
+        const updatedDeck = await prisma.deck.update({
+            where: {userId, id:deckId},
+            data: {
+                name: name,
+                cards: {
+                    deleteMany: {
+                        deckId: deckId,
+                    },
+                        create: cards.map((cardId: number) => ({ cardId })),
+                    }
+                }
+            });
+        return res.status(200).json("Deck updated successfully" + updatedDeck);
+    } catch (error: any) {
+        if (error.code === 'P2025') {
+            return res.status(404).json({error: "Deck not found"});
+        }
+        return res.status(500).json({error: "Internal server error"});
+    }
+});
+
+
+deckRouter.delete("/:id", authenticateToken, async (req: Request, res: Response) => {
+    try {
+        const userId = req.user!.userId;
+        const deckId = parseInt(req.params.id!);
+
+        if (isNaN(deckId)) {
+            return res.status(400).json("Invalid deck ID");
+        }
+
+        await prisma.deck.delete({
+            where: {userId, id:deckId},
+        });
+        return res.status(200).json("Deck deleted successfully"); 
+    }
+    catch (error: any) {
+        if (error.code === 'P2025') {
+            return res.status(404).json({error: "Deck not found"});
+        }
+        return res.status(500).json({error: "Internal server error"});
+    }
+});
+

--- a/src/routes/deck.routes.ts
+++ b/src/routes/deck.routes.ts
@@ -94,6 +94,14 @@ deckRouter.patch("/:id", authenticateToken, async (req: UpdateDeckRequest, res: 
             return res.status(400).json("A deck must contain exactly 10 cards");
         }
 
+        const deck = await prisma.deck.findFirst({
+            where: {userId, id: deckId}
+        });
+
+        if (!deck) {
+            return res.status(404).json({error: "Deck not found"});
+        }
+
         const updatedDeck = await prisma.deck.update({
             where: {userId, id:deckId},
             data: {
@@ -107,10 +115,7 @@ deckRouter.patch("/:id", authenticateToken, async (req: UpdateDeckRequest, res: 
                 }
             });
         return res.status(200).json("Deck updated successfully" + updatedDeck);
-    } catch (error: any) {
-        if (error.code === 'P2025') {
-            return res.status(404).json({error: "Deck not found"});
-        }
+    } catch (error) {
         return res.status(500).json({error: "Internal server error"});
     }
 });
@@ -125,15 +130,20 @@ deckRouter.delete("/:id", authenticateToken, async (req: Request, res: Response)
             return res.status(400).json("Invalid deck ID");
         }
 
+        const deck = await prisma.deck.findFirst({
+            where: {userId, id: deckId}
+        });
+
+        if (!deck) {
+            return res.status(404).json({error: "Deck not found"});
+        }
+
         await prisma.deck.delete({
             where: {userId, id:deckId},
         });
         return res.status(200).json("Deck deleted successfully"); 
     }
-    catch (error: any) {
-        if (error.code === 'P2025') {
-            return res.status(404).json({error: "Deck not found"});
-        }
+    catch (error) {
         return res.status(500).json({error: "Internal server error"});
     }
 });

--- a/src/routes/deck.routes.ts
+++ b/src/routes/deck.routes.ts
@@ -8,9 +8,8 @@ export const deckRouter = Router();
 
 deckRouter.post("/", authenticateToken, async (req: CreateDeckRequest, res: Response) => {
     try {
-        const name = req.body.name;
+        const { name, cards } = req.body;
         const userId = req.user!.userId;
-        const cards = req.body.cards;
 
         if (!name) {
             return res.status(400).json("Missing deck name");
@@ -147,4 +146,5 @@ deckRouter.delete("/:id", authenticateToken, async (req: Request, res: Response)
         return res.status(500).json({error: "Internal server error"});
     }
 });
+
 

--- a/src/types/auth.types.ts
+++ b/src/types/auth.types.ts
@@ -11,13 +11,13 @@ export interface SignInRequestBody {
         password: string;
     };
 
-export interface JWTRequestBody {
+export interface AuthenticatedRequest extends Request {
+    user: {
         userId: number;
         email: string;
+    }
 }
 
 export type SignUpRequest = Request<{}, any, SignUpRequestBody>;
 
 export type SignInRequest = Request<{}, any, SignInRequestBody>;
-
-export type JWTRequest = Request<{}, any, JWTRequestBody>;

--- a/src/types/auth.types.ts
+++ b/src/types/auth.types.ts
@@ -11,13 +11,7 @@ export interface SignInRequestBody {
         password: string;
     };
 
-export interface AuthenticatedRequest extends Request {
-    user: {
-        userId: number;
-        email: string;
-    }
-}
-
 export type SignUpRequest = Request<{}, any, SignUpRequestBody>;
 
 export type SignInRequest = Request<{}, any, SignInRequestBody>;
+

--- a/src/types/deck.types.ts
+++ b/src/types/deck.types.ts
@@ -1,0 +1,15 @@
+import type {Request} from 'express';
+
+export interface CreateDeckBody {
+    name: string;
+    cards: number[];
+}
+
+export interface UpdateDeckBody {
+    name: string;
+    cards: number[];
+}
+
+export type CreateDeckRequest = Request<any, any, CreateDeckBody>;
+
+export type UpdateDeckRequest = Request<any, any, UpdateDeckBody>;


### PR DESCRIPTION
Dans cette étape j'ai également appliqué du refactoring au niveau de quelques types pour les decks. J'ai également adapté plusieurs fois les routes, j'avais demandé à l'ia si je pouvais optimiser davantage le code des routes et elle m'avait proposé de tester l'erreur P2025, mais d'après notre échange ce n'est pas nécessaire, donc on reste sur un FindFirst() qui renvoie 404 s'il échoue. Le code trace à priori tous les scénarios possibles, je ne pense pas en avoir oublié. Les résultats sont les suivants avec Bruno :

<img width="1552" height="850" alt="image" src="https://github.com/user-attachments/assets/644e45dc-93a6-43f2-8beb-bf6acfefb998" />
decks red

<img width="1574" height="780" alt="image" src="https://github.com/user-attachments/assets/3eefd898-8d7a-4fd0-b455-8f8ba4f1f911" />
decks blue

<img width="1570" height="653" alt="image" src="https://github.com/user-attachments/assets/acf90698-2265-4e39-83cc-3d40041973e5" />
créer un deck (le crée et l'ajoute à la liste des decks de l'utilisateur connecté)

<img width="1564" height="725" alt="image" src="https://github.com/user-attachments/assets/8682371f-7b60-4dc1-bb61-d2f04eda0f00" />
update du deck (je remarque que l'affichage renvoie mal l'objet, je l'ai mal déclaré donc je l'adapterai ou le supprimerai)

<img width="1564" height="765" alt="image" src="https://github.com/user-attachments/assets/7be9b772-c70e-4d6d-b9ee-a88907c0b4e9" />
suppression du deck



J'ajoute concernant les 4 dernières modifications pour que les tests fonctionnent : le typage au niveau de l'authenticatedRequest ne passait pas. J'avais d'abord oublié de changer, puis modifié mais les tests ne fonctionnaient pas. La solution était déjà dans le code et implique simplement req.user! pour vérifier qu'il y a bien un user. Je peux sinon adapter le type createdeckrequest, selon ce qui est préférable.
